### PR TITLE
Handle unknown intents and fix final state retrieval

### DIFF
--- a/LangGraph.py
+++ b/LangGraph.py
@@ -29,7 +29,7 @@ workflow.add_node('recommend_food', recommend_food)
 workflow.add_node('recommend_activity', recommend_activity)
 workflow.add_node('generate_search_keyword', generate_search_keyword)
 workflow.add_node('search_place', search_place)
-workflow.add_node('summarize_messages', summarize_messages)
+workflow.add_node('summarize_massage', summarize_massage)
 workflow.add_node('intent_unkown', intent_unknown)
 
 #노드를 엣지로 연결
@@ -61,9 +61,9 @@ workflow.add_edge('recommend_activity', 'generate_search_keyword')
 #generate_search_keyword : 음식/활동별로 검색해 볼만한 키워드를 생성 
 #search_place : 실제로 만든 키워드로 '카카오맵'에 장소 검색
 workflow.add_edge('generate_search_keyword', 'search_place') 
-workflow.add_edge('search_place', 'summarize_messages')
+workflow.add_edge('search_place', 'summarize_massage')
 
-workflow.add_edge('summarize_messages', END)
+workflow.add_edge('summarize_massage', END)
 workflow.add_edge('intent_unkown', END)
 
 graph = workflow.compile()

--- a/agents_and_tools.py
+++ b/agents_and_tools.py
@@ -173,7 +173,7 @@ def search_place(state: dict) -> dict:
 
 
 # 9. 최종 메시지 생성
-def summarize_messages(state: dict) -> dict:
+def summarize_massage(state: dict) -> dict:
     item = state.get('recommend_items', ['추천'])[0]
     place = state.get('recommend_place', {})
     prompt = f"""
@@ -188,3 +188,13 @@ def summarize_messages(state: dict) -> dict:
         {'role': 'user', 'content': prompt.strip()}
     ])
     return {**state, 'final_message': response.content.strip()}
+
+
+# 10. 분류 불가 시 메시지 처리
+def intent_unknown(state: dict) -> dict:
+    """Generate a fallback message when the user's intent is unclear."""
+    message = (
+        "죄송하지만, 요청을 이해하지 못했어요. "
+        "음식이나 활동과 관련된 다른 질문을 해주세요."
+    )
+    return {**state, 'final_message': message}

--- a/app.py
+++ b/app.py
@@ -42,7 +42,11 @@ if submit:
          st.write('>> LangGraph 실행 완료! <<')
 
          #최종 상태 추출
-         final_state = events[-1].get('__end__') or events[-1].get('summarize_message', {})
+         final_state = (
+            events[-1].get('__end__')
+            or events[-1].get('summarize_massage')
+            or events[-1].get('intent_unkown', {})
+         )
          final_message = final_state.get('final_message', '추천 내용이 존재하지 않습니다.')
 
          st.session_state['last_result'] = final_state


### PR DESCRIPTION
## Summary
- Add a fallback `intent_unknown` node to provide a friendly message when user intent cannot be classified
- Correct final state retrieval in the Streamlit app and rename summary step to `summarize_massage` for consistency

## Testing
- `python -m py_compile agents_and_tools.py app.py LangGraph.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc83a6904832ab6001180f4ab3d96